### PR TITLE
Bug fix for read/write issue #9654

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/beanValidation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/beanValidation.mustache
@@ -1,15 +1,26 @@
-{{#required}}{{^isReadOnly}}{{^isWriteOnly}}
-    @NotNull 
-{{/isWriteOnly}}{{/isReadOnly}}{{/required}}
+{{#required}}
+{{!Mark the property as required and hence not null}}
+    {{^isReadOnly}}
+    {{!isReadOnly marks the property read only}}
+        {{^isWriteOnly}}
+        {{!isWriteOnly marks the property write only}}
+            @NotNull 
+        {{/isWriteOnly}}
+    {{/isReadOnly}}
+{{/required}}
 {{^isPrimitiveType}}
-{{^isDate}}
-{{^isDateTime}}
-{{^isString}}
-{{^isFile}}
-    @Valid 
-{{/isFile}}
-{{/isString}}
-{{/isDateTime}}
-{{/isDate}}
+    {{^isDate}}
+    * @Assert\Date()
+    * @Type("DateTime<'Y-m-d'>")
+        {{^isDateTime}}
+        * @Assert\Type("{{dataType}}")
+        * @Type("{{dataType}}")
+            {{^isString}}
+                {{^isFile}}
+                    @Valid 
+                {{/isFile}}
+            {{/isString}}
+        {{/isDateTime}}
+    {{/isDate}}
 {{/isPrimitiveType}}
-{{>beanValidationCore}}
+{{>beanValidationCore}} 

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/beanValidation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/beanValidation.mustache
@@ -1,1 +1,15 @@
-{{#required}}@NotNull {{/required}}{{^isPrimitiveType}}{{^isDate}}{{^isDateTime}}{{^isString}}{{^isFile}}@Valid {{/isFile}}{{/isString}}{{/isDateTime}}{{/isDate}}{{/isPrimitiveType}}{{>beanValidationCore}}
+{{#required}}{{^isReadOnly}}{{^isWriteOnly}}
+    @NotNull 
+{{/isWriteOnly}}{{/isReadOnly}}{{/required}}
+{{^isPrimitiveType}}
+{{^isDate}}
+{{^isDateTime}}
+{{^isString}}
+{{^isFile}}
+    @Valid 
+{{/isFile}}
+{{/isString}}
+{{/isDateTime}}
+{{/isDate}}
+{{/isPrimitiveType}}
+{{>beanValidationCore}}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Read / Write access specifier proper was not available for properties marked as required. Hence adding the read/write annotation to the bean class validator config in beanValidation.mustache file. 

This will help to have read/write only specifier for required property during Bean Class validation.

For required attributes, generate @NotNull only, if attribute is neither readOnly nor writeOnly.
This reflects the spec https://swagger.io/docs/specification/data-models/data-types/#readonly-writeonly

If a readOnly or writeOnly property is included in the required list, required affects just the relevant scope – responses only or requests only. That is, read-only required properties apply to responses only, and write-only required properties – to requests only.
Using @NotNull for these cases would fail validation in the other direction, where the attribute is intentionally not present.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
